### PR TITLE
botへのおみくじ対話機能の追加

### DIFF
--- a/.bash_history
+++ b/.bash_history
@@ -3,3 +3,17 @@ yo hubot-yarn
 git status
 bin/hubot
 exit
+yarn install
+pwd
+env HUBOT_SLACK_TOKEN=xoxb-483633276417-2446002723077-z5ZLgDYF4kv6hdAIPX6kg1Jq bin/hubot --adapter slack
+env HUBOT_SLACK_TOKEN=xoxb-483633276417-2446002723077-z5ZLgDYF4kv6hdAIPX6kg1Jq bin/hubot --adapter slack
+env HUBOT_SLACK_TOKEN=xoxb-483633276417-2446002723077-z5ZLgDYF4kv6hdAIPX6kg1Jq bin/hubot --adapter slack
+env HUBOT_SLACK_TOKEN=xoxb-483633276417-2446002723077-z5ZLgDYF4kv6hdAIPX6kg1Jq bin/hubot --adapter slack
+env HUBOT_SLACK_TOKEN=xoxb-483633276417-2446002723077-z5ZLgDYF4kv6hdAIPX6kg1Jq bin/hubot --adapter slack
+env HUBOT_SLACK_TOKEN=xoxb-483633276417-2446002723077-z5ZLgDYF4kv6hdAIPX6kg1Jq bin/hubot --adapter slack
+env HUBOT_SLACK_TOKEN=xoxb-483633276417-2446002723077-z5ZLgDYF4kv6hdAIPX6kg1Jq bin/hubot --adapter slack
+env HUBOT_SLACK_TOKEN=xoxb-483633276417-2446002723077-z5ZLgDYF4kv6hdAIPX6kg1Jq bin/hubot --adapter slack
+env HUBOT_SLACK_TOKEN=xoxb-483633276417-2446002723077-z5ZLgDYF4kv6hdAIPX6kg1Jq bin/hubot --adapter slack
+env HUBOT_SLACK_TOKEN=xoxb-483633276417-2446002723077-z5ZLgDYF4kv6hdAIPX6kg1Jq bin/hubot --adapter slack
+env HUBOT_SLACK_TOKEN=xoxb-483633276417-2446002723077-z5ZLgDYF4kv6hdAIPX6kg1Jq bin/hubot --adapter slack
+exit

--- a/.yarnrc
+++ b/.yarnrc
@@ -2,4 +2,4 @@
 # yarn lockfile v1
 
 
-lastUpdateCheck 1616480447519
+lastUpdateCheck 1630586201980

--- a/scripts/hello.js
+++ b/scripts/hello.js
@@ -4,4 +4,13 @@ module.exports = robot => {
     const user_id = msg.message.user.id;
     msg.send(`Hello, <@${user_id}>`);
   });
+
+  // REVIEW: 仕様に記載の"大吉, あなたのユーザー名"表記はメンション許容か要確認。user.profile.display_nameが使えずメンションで代用
+  robot.hear(/おみくじ/, msg => {
+    const lots = ['大吉', '吉', '中吉', '末吉', '凶'];
+    const lot = lots[Math.floor(Math.random() * lots.length)];
+    const user_id = msg.message.user.id;
+    msg.send(`${lot}, <@${user_id}>`);
+  });
+
 };


### PR DESCRIPTION
hubotに"おみくじ"という単語を確認すると吉凶の抽選結果を返す機能を追加しました。
仕様に記載のユーザ名の部分が実現できず、メンションを返す形の実装となっています。

練習用のプルリクエストのため、マージは不要です。